### PR TITLE
fix: use node:assert instead of vitest expect in storage test

### DIFF
--- a/src/test/storage-test-utils.ts
+++ b/src/test/storage-test-utils.ts
@@ -1,11 +1,11 @@
 import axios from 'axios';
-import { expect } from 'vitest';
+import assert from 'node:assert';
 import { Storage } from '../storage.js';
 
 export async function storageTest<TKey>(storage: Storage<TKey>, key: TKey) {
   // test to/from S3 key
   const s3Key = storage.keyConverter.toS3(key);
-  expect(storage.keyConverter.fromS3(s3Key)).toStrictEqual(key);
+  assert.deepStrictEqual(storage.keyConverter.fromS3(s3Key), key);
 
   // put/get/info/exists/delete
   const info = {
@@ -17,11 +17,11 @@ export async function storageTest<TKey>(storage: Storage<TKey>, key: TKey) {
     data: Buffer.from('DATA')
   };
   await storage.putObject(key, obj);
-  expect(await storage.exists(key)).toBe(true);
-  expect(await storage.getObject(key)).toEqual(obj);
-  expect(await storage.info(key)).toEqual(info);
+  assert.strictEqual(await storage.exists(key), true);
+  assert.deepStrictEqual(await storage.getObject(key), obj);
+  assert.deepStrictEqual(await storage.info(key), info);
   await storage.delete(key);
-  expect(await storage.exists(key)).toBe(false);
+  assert.strictEqual(await storage.exists(key), false);
 
   // Singed URLs
   const data = 'DATA';
@@ -29,10 +29,10 @@ export async function storageTest<TKey>(storage: Storage<TKey>, key: TKey) {
   await axios.put(putUrl, data, {
     headers: { 'content-type': info.contentType }
   });
-  expect(await storage.exists(key)).toBe(true);
+  assert.strictEqual(await storage.exists(key), true);
   const getUrl = await storage.signedGetUrl(key);
   const getUrlData = (await axios.get(getUrl)).data;
-  expect(getUrlData).toBe(data);
+  assert.deepStrictEqual(getUrlData, data);
   await storage.delete(key);
-  expect(await storage.exists(key)).toBe(false);
+  assert.strictEqual(await storage.exists(key), false);
 }


### PR DESCRIPTION
Use node:assert in place of vitest expect so there is no dependency on any exported code on vitest